### PR TITLE
Fix issue #1 -- Remove tests from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune linecache2/tests


### PR DESCRIPTION
Added a MANIFEST.in file to prune the linecache2/tests directory. Now
when an RPM is built the tests directory is no longer included in the RPM.
This is desirable because some of the python files in the tests directory
will not compile with python 2.x.
